### PR TITLE
1 removing marquee from scene does not kill tween

### DIFF
--- a/addons/marquee/marquee.gd
+++ b/addons/marquee/marquee.gd
@@ -75,6 +75,10 @@ func _rebuild():
 	custom_minimum_size = min_size
 	_relayout()
 
+func _exit_tree():
+	if _tween:
+		_tween.kill()
+
 func _on_resized():
 	_relayout()
 	

--- a/addons/marquee/plugin.cfg
+++ b/addons/marquee/plugin.cfg
@@ -3,5 +3,5 @@
 name="marquee"
 description="A control that acts as a marquee rotating labels at a customizable interval "
 author="markeel"
-version="1.0.0"
+version="1.0.1"
 script="plugin.gd"


### PR DESCRIPTION
Added the _exit_tree callback to kill the tween so it doesn't continually try to run if the node is removed from the scene tree.